### PR TITLE
Add basic actions

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -57,6 +57,7 @@ options can be set in configuration files:
   account.
 - :command:`AWS_SECRET_ACCESS_KEY`: The secret key for one's AWS account.
 - :command:`SITE_DIR`: The root directory of the static site.
+- :command:`DOMAIN`: The domain name.
 
 **Optional**
 
@@ -72,8 +73,8 @@ An example of running :command:`update` using environment variables for
 configuration is the following::
 
     export AWS_ACCESS_KEY_ID=MY_ACCESS_KEY_ID; export
-    AWS_SECRET_ACCESS_KEY=MY_SECRET_ACCESS_KEY; export SITE_DIR=./static; sdep
-    update
+    AWS_SECRET_ACCESS_KEY=MY_SECRET_ACCESS_KEY; export SITE_DIR=./static;
+    export DOMAIN=sdep-example.com; sdep update
 
 Configuration File
 ~~~~~~~~~~~~~~~~~~~
@@ -83,9 +84,10 @@ configuration values. A :command:`.sdeprc` file is just a simple JSON file, as
 con be seen below::
 
     {
-      aws_access_key_id: "MY_ACCESS_KEY_ID",
-      aws_secret_access_key: "MY_SECRET_ACCESS_KEY",
-      site_dir: "./static"
+      "aws_access_key_id": "MY_ACCESS_KEY_ID",
+      "aws_secret_access_key": "MY_SECRET_ACCESS_KEY",
+      "site_dir": "./static",
+      "domain": "sdep-example.com"
     }
 
 There are three possible ways to specify the location of a :command:`.sdeprc`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 pylint>=1.0
 nose2<=1.0
 mock==2.0.0
+moto<=1.0
 sphinx>=1.0
 sphinx-autobuild<=1.0
 sphinxcontrib-napoleon<=1.0

--- a/sdep/app.py
+++ b/sdep/app.py
@@ -82,6 +82,17 @@ class Sdep(object):
         self.upload_files_to_s3()
         self.configure_bucket_as_website()
 
+    def update(self):
+        """
+        Update the static website on AWS. This will perform the following
+        actions:
+        - Update static files that have changed.
+        """
+        # Because s3 uses the same operations for `create` and `updating` an
+        # object on s3, we can just reuse the same function.
+        # @TODO In the future, we should only update the files that changed.
+        self.upload_files_to_s3()
+
     def create_s3_buckets(self):
         """
         Create the buckets in which we will place the static content.
@@ -196,11 +207,3 @@ class Sdep(object):
         }
 
         return website_config
-
-    def update(self):
-        """
-        Update the static website on AWS. This will perform the following
-        actions:
-        - Update static files that have changed.
-        """
-        pass

--- a/sdep/app.py
+++ b/sdep/app.py
@@ -3,6 +3,16 @@ This file contains the `Sdep` class as well as any related classes and functions
 necessary for creating and updating a static website on AWS.
 """
 
+# pylint: disable=import-error
+
+import os
+
+import boto3
+
+import simplejson as json
+
+from .config import Config
+
 class Sdep(object):
     """
     An instance of this `Sdep` class is responsible for defining all actions
@@ -15,16 +25,177 @@ class Sdep(object):
         sdep: An instance of the `Sdep` class.
     """
 
+    # Constant names of AWS objects.
+    BUCKET_NAME = "bucket_name"
+
+    # Default index and error.
+    # @TODO This specification is temporary, as eventually we will make these
+    # configurable options with `Config`.
+    DEFAULT_INDEX_SUFFIX = "index.html"
+    DEFAULT_ERROR_KEY = "404.html"
+
     def __init__(self, config):
         self._config = config
+        self._s3_client = self._establish_s3_client()
+
+    @property
+    def config(self):
+        """
+        Read only access of this instance's `Config` instance.
+
+        We make this publicly accessible because often during testing we need to
+        update configuration values on the fly (mostly for inserting the name of
+        test directories).
+
+        @TODO Would it be better to do this through just mocking individual
+        calls?
+
+        Returns:
+            Config: The configuration for this file.
+        """
+        return self._config
+
+    def _establish_s3_client(self):
+        """
+        Return a boto3 client connected to s3 with the configured auth tokens.
+
+        Returns:
+            S3.Client: The client we use to communicate with s3.
+        """
+        # We will not even be attempting to create an instance of the `Sdep`
+        # class, unless these values exist, so we are confident they do.
+        access_key = self.config.get(Config.AWS_ACCESS_KEY_ID_FIELD)
+        secret_key = self.config.get(Config.AWS_SECRET_ACCESS_KEY_FIELD)
+
+        return boto3.client("s3", aws_access_key_id=access_key,
+                            aws_secret_access_key=secret_key)
 
     def create(self):
         """
         Perform the initial creation of the static website on AWS. This command
         will perform the following actions:
-        - Perform the initial upload of the static files.
+        - Create the s3 buckets with the proper permissions.
+        - Upload all of the files.
+        - Configure the s3 bucket to serve as a website.
         """
-        pass
+        self.create_s3_buckets()
+        self.upload_files_to_s3()
+        self.configure_bucket_as_website()
+
+    def create_s3_buckets(self):
+        """
+        Create the buckets in which we will place the static content.
+
+        AWS specifies that we must name the bucket the same name as our domain.
+        """
+        bucket_name = self._bucket_name()
+
+        self._s3_client.create_bucket(Bucket=bucket_name)
+        self._s3_client.put_bucket_policy(
+            Bucket=bucket_name, Policy=self._public_bucket_policy(bucket_name))
+
+        # @TODO
+        # This is where we will perform the check to see if we should also
+        # create a `www.` subdomain bucket in addition to check if the
+        # configuration specifies a region.
+
+        # @TODO This is where we will optionally configure logging (which would
+        # require the creation of additional buckets).
+
+    def upload_files_to_s3(self):
+        """
+        Upload every file from the static website directory to s3.
+        """
+        site_dir = self.config.get(Config.SITE_DIR_FIELD)
+
+        for path, _, files in os.walk(site_dir):
+            for file_name in files:
+                full_path = os.path.join(path, file_name)
+
+                # We want the key name to be the full path, assuming we treat
+                # `site_dir` as the root. We add `+ 1` to cut off a `/`.
+                key_name = full_path[len(site_dir) + 1:]
+
+                self._s3_client.upload_file(full_path, self._bucket_name(),
+                                            key_name)
+
+    def configure_bucket_as_website(self):
+        """
+        For a bucket to serve as a static website, AWS requires some specific
+        configuration.
+        """
+        self._s3_client.put_bucket_website(
+            Bucket=self._bucket_name(),
+            WebsiteConfiguration=self._website_config()
+        )
+
+    def aws_naming(self):
+        """
+        Many of our methods for generating the names that we use for AWS objects
+        (like buckets) are private, which makes sense. However, often in tests
+        we need to access these names. As such, this method returns a hash of
+        all AWS specific names. The implementation of this method means we can
+        access the information while keeping private methods private.
+
+        Returns:
+            dict: A dictionary of the names of aws objects.
+        """
+        return {self.BUCKET_NAME: self._bucket_name()}
+
+
+    def _bucket_name(self):
+        """
+        The name of the bucket we use for hosting our static site.
+
+        Returns:
+            str: The bucket name.
+        """
+        return self.config.get(Config.DOMAIN_FIELD)
+
+    @staticmethod
+    def _public_bucket_policy(bucket_name):
+        """
+        A helper method for getting a bucket policy which allows anyone to view
+        our static website.
+
+        Args:
+            bucket_name (str): The bucket for which we are creating the policy.
+
+        Returns:
+            str: A json dump of the policy.
+        """
+
+        json_policy = {
+            "Version":"2012-10-17",
+            "Statement": [{
+                "Sid": "Allow Public Access to All Objects",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::{0}/*".format(bucket_name)
+            }]
+        }
+
+        return json.dumps(json_policy)
+
+    def _website_config(self):
+        """
+        Helper method returning the configuration for the api call to transform
+        our bucket into a website.
+
+        Returns:
+            dict: Configuration stored within a dictionary.
+        """
+        website_config = {
+            "IndexDocument": {
+                "Suffix": self.DEFAULT_INDEX_SUFFIX
+            },
+            "ErrorDocument": {
+                "Key": self.DEFAULT_ERROR_KEY
+            }
+        }
+
+        return website_config
 
     def update(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
     keywords=['deployments', 'cli'],
     # Dependencies for `sdep`.
     install_requires=[
+        'boto3>=1.0.0',
         'click>=6.0',
-        'simplejson>=3.0'
+        'simplejson>=3.0',
     ]
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,6 +44,14 @@ class SdepTestCase(unittest.TestCase):
         pass
 
     @mock_s3
+    def test_upload(self):
+        """
+        Like `test_create`, we do not test the `upload` method because we test
+        the individual components.
+        """
+        pass
+
+    @mock_s3
     def test_create_s3_buckets(self):
         """
         Test that creating s3 buckets works successfully.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,142 @@
+"""
+Tests for `app.py`, particularly the `Sdep` class.
+"""
+
+# pylint: disable=import-error
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from collections import namedtuple
+
+import boto3
+
+from moto import mock_s3
+
+from sdep.app import Sdep
+from sdep.config import Config
+
+class SdepTestCase(unittest.TestCase):
+    """
+    Test cases for the `Sdep` class.
+    """
+
+    # UploadInfo is a helper named tuple making it easier to return information
+    # from `SdepTestCase#_create_test_upload_dir`. It is defined within the
+    # `SdepTestCase` class because it will never be used externally.
+    UploadInfo = namedtuple("UploadInfo", "tmp_dir num_files created_keys")
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+
+        self._sdep = Sdep(config=Config(test_mode=True))
+        self._s3_client = boto3.client("s3", aws_access_key_id="TEST_ID",
+                                       aws_secret_access_key="TEST_KEY")
+
+    @mock_s3
+    def test_create(self):
+        """
+        For now, we do not test this method because we test of the individual
+        components, and the individual components do not interact at all.
+        """
+        pass
+
+    @mock_s3
+    def test_create_s3_buckets(self):
+        """
+        Test that creating s3 buckets works successfully.
+        """
+        self._sdep.create_s3_buckets()
+
+        # Confirm that we created the single bucket for storing our website.
+        # This test will become more complicated once we have the option of also
+        # creating a `www` subdomain bucket and a `logs` bucket.
+        resp_buckets = self._s3_client.list_buckets()["Buckets"]
+        self.assertEqual(1, len(resp_buckets))
+
+        bucket = resp_buckets[0]
+        bucket_name = self._sdep.aws_naming()[Sdep.BUCKET_NAME]
+        self.assertEqual(bucket["Name"], bucket_name)
+
+        # Confirm that our bucket has the proper usage policy.
+        resp = self._s3_client.get_bucket_policy(Bucket=bucket_name)
+        self.assertTrue(len(resp["Policy"]) > 0)
+
+    @mock_s3
+    def test_upload_files_to_s3(self):
+        """
+        Test uploading test files to s3 works successfully.
+
+        We create (and then delete) tmp directory containing two files (one
+        should be nested in a directory), which we upload tos3. We then check
+        that two files have been uploaded to the bucket.
+        """
+        # Setup by first creating the bucket (we must do this because every test
+        # has a new `@mock_s3` environment).
+        self._sdep.create_s3_buckets()
+
+        upload_info = self._create_test_upload_dir()
+        self._sdep.config.put(Config.SITE_DIR_FIELD, upload_info.tmp_dir)
+
+        self._sdep.upload_files_to_s3()
+
+        bucket_name = self._sdep.aws_naming()[Sdep.BUCKET_NAME]
+        resp_objects = self._s3_client.list_objects(Bucket=bucket_name)
+        contents = resp_objects["Contents"]
+
+        self.assertEqual(len(contents), upload_info.num_files)
+
+        returned_keys = [c["Key"] for c in contents]
+        for key in upload_info.created_keys:
+            self.assertTrue(key in returned_keys)
+
+        shutil.rmtree(upload_info.tmp_dir, ignore_errors=True)
+
+    @mock_s3
+    def test_configure_bucket_website(self):
+        """
+        Test configuring the bucket to work as a website works successfully.
+        """
+        self._sdep.create_s3_buckets()
+        self._sdep.configure_bucket_as_website()
+
+        bucket_name = self._sdep.aws_naming()[Sdep.BUCKET_NAME]
+
+        # @TODO Again we will need to update this once we make
+        # `IndexDocument#Suffix` and `ErrorDocument#Key` optionally configurable
+        # with `Config`.
+        resp = self._s3_client.get_bucket_website(Bucket=bucket_name)
+
+        self.assertEqual(resp["IndexDocument"]["Suffix"],
+                         Sdep.DEFAULT_INDEX_SUFFIX)
+        self.assertEqual(resp["ErrorDocument"]["Key"], Sdep.DEFAULT_ERROR_KEY)
+
+    @classmethod
+    def _create_test_upload_dir(cls):
+        """
+        Create a temporary directory simulating the directory containing the
+        static files for a website.
+
+        Returns:
+            UploadInfo: A named tuple containing the path to the temp directory, the
+            number of files we created, and names of the files (keys) we expect
+            to be uploaded.
+        """
+        dir_name = tempfile.mkdtemp()
+        subdir_name = os.path.join(dir_name, "public")
+
+        os.makedirs(subdir_name)
+
+        index_file = os.path.join(dir_name, "index.html")
+        js_file = os.path.join(subdir_name, "index.js")
+
+        created_files = [index_file, js_file]
+
+        for file_to_write in created_files:
+            with open(file_to_write, "w+") as test_file:
+                test_file.write("TEST")
+
+        return cls.UploadInfo(tmp_dir=dir_name, num_files=len(created_files),
+                              created_keys=["index.html", "public/index.js"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,7 +35,7 @@ class ConfigTestCase(unittest.TestCase):
         for field in Config.required_config_fields():
             self.assertNotEqual(config.get(field), None)
 
-        self._cleanup_file(config_file)
+        os.remove(config_file)
 
     def test_load_config_from_env(self):
         """
@@ -67,7 +67,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertNotEqual(Config.locate_config_file(), None)
 
         if created_file:
-            self._cleanup_file(curr_dir_loc)
+            os.remove(curr_dir_loc)
 
     def test_find_config_in_home_dir(self):
         """
@@ -88,7 +88,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertNotEqual(Config.locate_config_file(), None)
 
         if created_file:
-            self._cleanup_file(home_dir_loc)
+            os.remove(home_dir_loc)
 
     def test_bad_config(self):
         """
@@ -146,13 +146,3 @@ class ConfigTestCase(unittest.TestCase):
             bad_config_file.write(json.dumps({}))
 
         return file_name
-
-    @staticmethod
-    def _cleanup_file(file_path):
-        """
-        Delete the temporary configuration file we created.
-
-        Args:
-            file_path (str): The path to the file we wish to delete.
-        """
-        os.remove(file_path)


### PR DESCRIPTION
Fix #9 

This merge contains the `S3` portion of the `create` and `update` actions.
This commit could work, but it would require manually pointing your
domain's DNS A record at the S3 domain, and would not include
any server-side caching.
