### PR TITLE
Bump version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ Services, Cloudfront, and Route 53.
 
 from setuptools import setup
 
-VERSION = '0.1'
+VERSION = '0.11'
 
 setup(
     name='sdep',
-    # Automatically read the version from `sdep/__init__.py`.
+    # @TODO Automatically read the version from `sdep/__init__.py`.
     version=VERSION,
     description='A cli for easily deploying static websites',
     author='Matt McNaughton',


### PR DESCRIPTION
We started at version `.10`. Since we added functionality to the
`create` and `update` methods and have something that should at least
basically work, we call this version `.11`.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
