### PR TITLE
Run `sdep` from command line

### DIFF
--- a/sdep-runner.py
+++ b/sdep-runner.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+"""
+A helper script for running `sdep` directly from the source tree, as if we
+downloaded `sdep` with `pip install sdep` and then run `sdep` from the command
+line.
+
+Make sure the user has permission to execute with `chmod u+x sdep-runner.py`.
+"""
+
+# pylint: disable=invalid-name
+
+from sdep.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/sdep/__main__.py
+++ b/sdep/__main__.py
@@ -1,0 +1,7 @@
+"""
+sdep.__main__ is executed when `sdep` is called as a script from the command
+line.
+"""
+
+from .cli import main
+main()

--- a/sdep/cli.py
+++ b/sdep/cli.py
@@ -65,6 +65,10 @@ def cli(action, config, test):
             elif action == Actions.UPDATE:
                 sdep.update()
 
-if __name__ == '__main__':
+def main():
+    """
+    The `main` function will be run when we execute `$ sdep create...` from the
+    terminal.
+    """
     # pylint: disable=no-value-for-parameter
     cli()

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,12 @@ setup(
         'boto3>=1.0.0',
         'click>=6.0',
         'simplejson>=3.0',
-    ]
+    ],
+    # Install `sdep` to the user's site-packages directory.
+    packages=["sdep"],
+    # Tell pip to generate a script called `sdep` which will invoke
+    # `sdep.cli:main`.
+    entry_points={
+        "console_scripts": ["sdep = sdep.cli:main"]
+    }
 )


### PR DESCRIPTION
Fix #26 

Modify `setup.py` to automatically generate a script to run
`sdep.cli:main` from the terminal with `sdep` after `pip install sdep`.
Additionally, create a helper file called `sdep-runner.py` which simulates
running `sdep` from the command line.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
