### PR TITLE
Dynamically read version from `__init__.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.pyc
 __pycache__
 dist
+build
 *.egg
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
   - "2.7"

--- a/sdep/__init__.py
+++ b/sdep/__init__.py
@@ -1,3 +1,6 @@
 """
 The base module file for `sdep`.
 """
+
+# The version for `sdep` package, which we read in from `setup.py`.
+__version__ = 0.11

--- a/setup.py
+++ b/setup.py
@@ -6,27 +6,34 @@ sdep is a cli for easily deploying a static website using Amazon Web
 Services, Cloudfront, and Route 53.
 """
 
+# pylint: disable=invalid-name
+
+import re
+
 from setuptools import setup
 
-VERSION = '0.11'
+# Read the version number in from `sdep/__init__.py`.
+with open("sdep/__init__.py", "rb") as init_file:
+    file_contents = init_file.read().decode("utf-8")
+    version_re = re.compile(r"__version__\s+=\s+(.*)")
+    version = version_re.search(file_contents).group(1)
 
 setup(
-    name='sdep',
-    # @TODO Automatically read the version from `sdep/__init__.py`.
-    version=VERSION,
-    description='A cli for easily deploying static websites',
-    author='Matt McNaughton',
-    license='MIT',
-    author_email='mattjmcnaughton@gmail.com',
-    url='https://github.com/mattjmcnaughton/sdep',
+    name="sdep",
+    version=version,
+    description="A cli for easily deploying static websites",
+    author="Matt McNaughton",
+    license="MIT",
+    author_email="mattjmcnaughton@gmail.com",
+    url="https://github.com/mattjmcnaughton/sdep",
     # Make sure to tag releases appropriately.
-    download_url="https://github.com/mattjmcnaughton/sdep/tarball/{0}".format(VERSION),
-    keywords=['deployments', 'cli'],
+    download_url="https://github.com/mattjmcnaughton/sdep/tarball/{0}".format(version),
+    keywords=["deployments", "cli"],
     # Dependencies for `sdep`.
     install_requires=[
-        'boto3>=1.0.0',
-        'click>=6.0',
-        'simplejson>=3.0',
+        "boto3>=1.0.0",
+        "click>=6.0",
+        "simplejson>=3.0",
     ],
     # Install `sdep` to the user's site-packages directory.
     packages=["sdep"],


### PR DESCRIPTION
Fix #27 

Instead of hard coding the version number in `setup.py`, instead we read
the value from `sdep/__init__.py`, as is done in the `flask` project.

Additionally, this commit modifies `.travis.yml` so that `travis` caches `pip`
dependencies, which should speed up build times.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
