### PR TITLE
Add ContentTypes when S3 uploading

### DIFF
--- a/examples/example.md
+++ b/examples/example.md
@@ -1,3 +1,3 @@
-# Example
+Example
 
 Instructions for a local deploy.


### PR DESCRIPTION
Previously, we did not specify ContentTypes when uploading files to S3,
causing every file to be downloaded, as the browser considered it an
`binary/octet-stream`. As we now specify the correct `ContentType`, the
browser will render the HTML, CSS...

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
