### PR TITLE
Expand ContentType Handling

### DIFF
--- a/sdep/__init__.py
+++ b/sdep/__init__.py
@@ -3,4 +3,4 @@ The base module file for `sdep`.
 """
 
 # The version for `sdep` package, which we read in from `setup.py`.
-__version__ = 0.20
+__version__ = 0.21

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -120,6 +120,27 @@ class SdepTestCase(unittest.TestCase):
         self.assertNotEqual(resp["IndexDocument"]["Suffix"], None)
         self.assertNotEqual(resp["ErrorDocument"]["Key"], None)
 
+    def test_predict_content_type(self):
+        """
+        There are some strange edge cases having to do with the setting the
+        `ContentType` metadata for files, so we perform some tests just to make
+        sure our module is working as expected.
+        """
+        poss_keys = [
+            "index.html",
+            "pic.jpg",
+            "style.css",
+            "main.js",
+            "fontawesome/fonts/fontawesome-webfont.eot",
+            "fontawesome/fonts/fontawesome-webfont.woff",
+            "fontawesome/fonts/fontawesome-webfont.woff2",
+            "fontawesome/fonts/FontAwesome.otf",
+            "fontawesome/fonts/fontawesome-webfont.ttf"
+        ]
+
+        for key in poss_keys:
+            self.assertNotEqual(Sdep.predict_content_type(key), None)
+
     @classmethod
     def _create_test_upload_dir(cls):
         """


### PR DESCRIPTION
We now support the proper content type for eot, otf, and ttf file types,
which is necessary when deploying a static site generated by Hugo.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
