### PR TITLE
Expand supported ContentTypes

### DIFF
--- a/sdep/__init__.py
+++ b/sdep/__init__.py
@@ -7,4 +7,4 @@ from .config import Config
 from .cli import cli
 
 # The version for `sdep` package, which we read in from `setup.py`.
-__version__ = 0.30
+__version__ = 0.31

--- a/sdep/app.py
+++ b/sdep/app.py
@@ -241,7 +241,10 @@ class Sdep(object):
             "eot": "application/vnd.ms-fontobject",
             "ttf": "application/font-sfnt",
             "woff": "application/font-woff",
-            "otf": "font/opentype"
+            "otf": "font/opentype",
+            "scss": "text/css",
+            "sass": "text/css",
+            "htc": "text/x-component"
         }
 
         if content_type is None:
@@ -251,4 +254,7 @@ class Sdep(object):
                 if extension in file_extension:
                     content_type = poss_type
 
-        return content_type
+        # The content type to return if we unable to match.
+        default_content_type = "text/plain"
+
+        return content_type or default_content_type

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -135,7 +135,11 @@ class SdepTestCase(unittest.TestCase):
             "fontawesome/fonts/fontawesome-webfont.woff",
             "fontawesome/fonts/fontawesome-webfont.woff2",
             "fontawesome/fonts/FontAwesome.otf",
-            "fontawesome/fonts/fontawesome-webfont.ttf"
+            "fontawesome/fonts/fontawesome-webfont.ttf",
+            "test/style.scss",
+            "test/style.sass",
+            "test/test.htc",
+            "test/test.nomatch"
         ]
 
         for key in poss_keys:


### PR DESCRIPTION
When trying to use sdep to deploy a new site, I noticed more ContentType
mappings that were missing. This commit adds them, in addition to adding
a sensible default case for if a mapping cannot be found.

Bump to 0.31 to resolve these issues.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
