### PR TITLE
Reset semver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+A Changelog, following the format specified by [Keep A
+CHANGELOG](http://keepachangelog.com/). **Sdep** follows
+[semver](http://semver.org/).
+
+## 0.1.0 (2016-6-17)
+
+### Added
+
+- Our initial release, which works as desired and defines skeleton functionality.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -3,7 +3,7 @@
 Command Line Interface
 ======================
 
-.. versionadded:: 0.1
+.. versionadded:: 0.1.0
 
 The primary method of running **sdep** is through the command line interface. We use
 `click <http://click.pocoo.org/>`_ to easily create a command line interface. It

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -3,7 +3,7 @@
 Quickstart Example
 ==================
 
-.. versionadded:: 0.3
+.. versionadded:: 0.1.0
 
 The following example demonstrates using **sdep** to create a static website. In
 addition to **sdep**, and Amazon S3, we utilize `travis-ci
@@ -112,7 +112,7 @@ a :command:`.travis.yml` file with the following contents::
     sudo: required
     script:
     - hugo -v
-    - sudo pip install sdep>=0.30
+    - sudo pip install sdep>=0.1.0
     - sdep update
     branches:
       only:

--- a/sdep/__init__.py
+++ b/sdep/__init__.py
@@ -7,4 +7,4 @@ from .config import Config
 from .cli import cli
 
 # The version for `sdep` package, which we read in from `setup.py`.
-__version__ = 0.31
+__version__ = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ sdep is a cli for easily deploying a static website using S3.
 
 # pylint: disable=invalid-name
 
+import ast
 import re
 
 from setuptools import setup
@@ -15,7 +16,7 @@ from setuptools import setup
 with open("sdep/__init__.py", "rb") as init_file:
     file_contents = init_file.read().decode("utf-8")
     version_re = re.compile(r"__version__\s+=\s+(.*)")
-    version = version_re.search(file_contents).group(1)
+    version = str(ast.literal_eval(version_re.search(file_contents).group(1)))
 
 setup(
     name="sdep",


### PR DESCRIPTION
Fix #21 

I want to version this project with `semver`. However, I was not
properly specifying the version number in that format, as I did not
specify a patch number. This commit basically starts the versioning over
at `0.1.0`, the first working release. I deleted all previous versions
on pypi and Github tags, meaning we are completely starting over at
`0.1.0`.

After this commit, we will more closely adhere to semver, as well as
utilizing the Changelog.

Signed-off-by: mattjmcnaughton mattjmcnaughton@gmail.com
